### PR TITLE
Help Command & Command Documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+compose.yml
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+CONTRIBUTING.md
+.git

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,119 @@
+# Jasper User Documentation
+
+This document provides information and intructions on all of Jasper's functionalities.
+
+## Commands
+
+Commands prefixed with a `/` are app command compatible and commands with `?` are message (prefix) compatible. Required parameters will be
+wrapped in `<>` while optional parameters are wrapped in `[]` brackets.
+
+### `/` `resolve` [*original_question*] [*summarized_answer*]
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Close a forum post with a finalizing message.
+
+> **Feature Flags**: `-`
+
+### `/` `tags` `create`
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Create a new tag.
+
+> **Feature Flags**: `Modal`
+
+### `/` `tags` `list`
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: List all tags for the current guild.
+
+> **Feature Flags**: `-`
+
+### `/` `tags` `delete` <_tag_name_>
+
+> **Permissions**: `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Delete a tag.
+
+> **Feature Flags**: `Autocomplete`
+
+### `/` `tags` `edit`
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Edit a tag.
+
+> **Feature Flags**: `Modal`
+
+### `/` `tags` `info` <_tag_name_>
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Get information about a tag.
+
+> **Feature Flags**: `Autocomplete`
+
+### `/` `tags` `show` <_tag_name_>
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Show a tag.
+
+> **Feature Flags**: `Autocomplete`
+
+### `/` `tags` `use` <_tag_name_>
+
+> **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Use a tag.
+
+> **Feature Flags**: `Autocomplete`
+
+## Message Commands
+
+Message Commands are triggered by specific message prefixes and provide various functionalities. Below are the details of the available
+message commands.
+
+### Prefixes
+
+The following prefixes are recognized by the command handler:
+
+- `yo`
+- `w`
+- `dude,`
+- `omg`
+- `lookhere`
+- `j`
+
+### Parameters and Actions
+
+Commands can include additional parameters and actions prefixed by a dash (`-`). Parameters and actions modify the behavior of the command.
+The recognized actions are:
+
+- `-mention` or `-m`: Mention a specific user in the response.
+- `-del` or `-d`: Delete the original command message after executing the command.
+
+### Command Structure
+
+A command is structured as follows:
+
+```plaintext
+<prefix> <command> [parameters] [actions]
+```
+
+Example:
+
+```plaintext
+yo tagname -mention @username -del
+```
+
+### Permissions
+
+The command execution requires the user to have one of the following roles:
+
+- `ADMIN_ROLE`
+- `STAFF_ROLE`
+- `SUPPORT_ROLE`
+

--- a/Plugins/Tags/Commands/HelpCommand.ts
+++ b/Plugins/Tags/Commands/HelpCommand.ts
@@ -1,0 +1,102 @@
+import { ApplicationCommandOptionType, ApplicationCommandType } from "@antibot/interactions";
+import { DefineCommand } from "../../../Common/DefineCommand";
+import { ChatInputCommandInteraction } from "discord.js";
+import fs from 'fs';
+import path from 'path';
+
+type DocumentationItem = {
+    name: string;
+    value: string;
+};
+
+/**
+ * Autocomplete topics and subtopics from the documentation content.
+ * @param content The documentation content.
+ * @returns An array of objects with "name" and "value" fields.
+ */
+function autocomplete(content: string): DocumentationItem[] {
+    const lines = content.split('\n');
+    const result: DocumentationItem[] = [];
+    let currentTopic: string | null = null;
+    let currentSubtopic: string | null = null;
+    let currentContent: string[] = [];
+
+    const addCurrentItem = () => {
+        if (currentSubtopic && currentContent.length > 0) {
+            result.push({
+                name: `${ currentTopic } > ${ currentSubtopic }`,
+                value: currentContent.join('\n').trim()
+            });
+        } else if (currentTopic && !currentSubtopic && currentContent.length > 0) {
+            result.push({
+                name: currentTopic,
+                value: currentContent.join('\n').trim()
+            });
+        }
+    };
+
+    for (const line of lines) {
+        if (line.startsWith('## ')) {
+            addCurrentItem();
+            currentTopic = line.substring(3).trim();
+            currentSubtopic = null;
+            currentContent = [];
+        } else if (line.startsWith('### ')) {
+            addCurrentItem();
+            currentSubtopic = line.substring(4).trim();
+            currentContent = [];
+        } else if (line.trim().length > 0) {
+            currentContent.push(line);
+        }
+    }
+    addCurrentItem();
+    return result;
+}
+
+export const HelpCommand = DefineCommand<ChatInputCommandInteraction>({
+    command: {
+        name: "help",
+        type: ApplicationCommandType.CHAT_INPUT,
+        description: "Displays the documentation for the bot",
+        options: [
+            {
+                type: ApplicationCommandOptionType.STRING,
+                name: "section",
+                description: "The section of the documentation to display",
+                required: true,
+                autocomplete: true,
+            },
+        ],
+    },
+    on: async (_, interaction) => {
+        const documentationPath = path.join(__dirname, '..', '..', '..', '..', 'DOCUMENTATION.md');
+        const documentationContent = fs.readFileSync(documentationPath, 'utf-8');
+
+        const section = interaction.options.getString("section", true);
+        const choices = autocomplete(documentationContent);
+
+        const choice = choices.find(c => c.name === section);
+
+        const embed = {
+            title: choice.name.replace('Commands > ', ''),
+            description: choice.value,
+            color: 0xff9a00
+        };
+
+        await interaction.reply({ embeds: [ embed ], ephemeral: true });
+    },
+    autocomplete: async (_, interaction) => {
+        const documentationPath = path.join(__dirname, '..', '..', '..', '..', 'DOCUMENTATION.md');
+        const documentationContent = fs.readFileSync(documentationPath, 'utf-8');
+
+        const choices = autocomplete(documentationContent);
+
+        // Send the choices as an autocomplete response
+        await interaction.respond(
+            choices.map(choice => ({
+                name: choice.name.replaceAll(/([/`*]|<_|_>)*/g, ''),
+                value: choice.name
+            })).slice(0, 20)
+        );
+    }
+});

--- a/Plugins/Tags/Commands/TagCommand.ts
+++ b/Plugins/Tags/Commands/TagCommand.ts
@@ -19,6 +19,7 @@ import {
     UseSubCommand
 } from "../SubCommands";
 import { CheckForRoles } from "../../../Common/CheckForRoles";
+import { TagGet } from "../Controllers/TagGet";
 
 const subCommands: ApplicationCommandOptions[] = [
     CreateSubCommand,
@@ -39,16 +40,20 @@ export const TagCommand = DefineCommand<ChatInputCommandInteraction>({
     },
     on: async (ctx: Context, interaction) => {
         const subCommand = interaction.options.getSubcommand();
+
         if (subCommand === "delete") {
-          if (CheckForRoles(interaction, process.env.ADMIN_ROLE, process.env.STAFF_ROLE)) {
-            await RunDeleteSubCommand(ctx, interaction);
-          } else {
-              return interaction.reply({
-                content: "Sorry but you can't use this command.",
-                ephemeral: true,
-            });
-          }
-      }
+            const tag = interaction.options.getString("tag");
+            const dbTag = await TagGet(tag, interaction.guild.id, ctx);
+
+            if (CheckForRoles(interaction, process.env.ADMIN_ROLE, process.env.STAFF_ROLE) || dbTag.TagAuthor === interaction.user.id) {
+                await RunDeleteSubCommand(ctx, interaction);
+            } else {
+                return interaction.reply({
+                    content: "Sorry but you can't use this command.",
+                    ephemeral: true,
+                });
+            }
+        }
 
         if (CheckForRoles(interaction, process.env.ADMIN_ROLE, process.env.STAFF_ROLE, process.env.SUPPORT_ROLE)) {
             if (subCommand === "create") {

--- a/Plugins/Tags/TagsPlugin.ts
+++ b/Plugins/Tags/TagsPlugin.ts
@@ -1,10 +1,10 @@
 import { DefinePlugin, Plugin } from "../../Common/DefinePlugin";
-import { ResolveCommand, TagCommand, TagCreateModal, TagEditModal, TagEvent, } from ".";
+import { HelpCommand, ResolveCommand, TagCommand, TagCreateModal, TagEditModal, TagEvent } from ".";
 
 export = DefinePlugin({
     name: "tags",
     description: "Tags for the No Text To Speech support team!",
-    commands: [ TagCommand, ResolveCommand ],
+    commands: [ TagCommand, ResolveCommand, HelpCommand ],
     events: [ TagCreateModal, TagEditModal, TagEvent ],
     public_plugin: true,
 }) as Plugin;

--- a/Plugins/Tags/index.ts
+++ b/Plugins/Tags/index.ts
@@ -3,3 +3,4 @@ export * from "./Commands/ResolveCommand";
 export * from "./Modals/TagCreateModal";
 export * from "./Modals/TagEditModal";
 export * from "./Events/TagEvent";
+export * from "./Commands/HelpCommand";


### PR DESCRIPTION
Add HelpCommand to TagsPlugin and update tag deletion logic

In this update, I have added a new functionality into TagsPlugin by adding the HelpCommand. This feature will help to display bot documentation effectively. In addition, we've made a modification to the tag deletion logic so that the author of a tag also has the ability to delete the tag. Besides this, new '.dockerignore' file was created, and the user documentation was updated to reflect these changes.